### PR TITLE
Upgrade libthrift to version 0.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
          <artifactId>commons-compress</artifactId>
          <version>1.24.0</version>
       </dependency>
+      <dependency>
+         <groupId>org.apache.thrift</groupId>
+         <artifactId>libthrift</artifactId>
+         <version>0.15.0</version>
+      </dependency>
    </dependencies>
 
     <build>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades libthrift to 0.15.0 to fix vulnerabilities in current version