### PR TITLE
Upgrade json-smart to version 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
          <artifactId>commons-compress</artifactId>
          <version>1.24.0</version>
       </dependency>
+      <dependency>
+         <groupId>net.minidev</groupId>
+         <artifactId>json-smart</artifactId>
+         <version>2.5.1</version>
+      </dependency>
    </dependencies>
 
     <build>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades json-smart to 2.5.1 to fix vulnerabilities in current version